### PR TITLE
local compute for demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,19 @@ The following environment variables can be specified. They can be provided via a
 * MOS_COMPUTE_CONN_RETRIES_INT:
 * MOS_COMPUTE_CONN_RETRIES_MAX:
 
+### Configuration for MOS Demo
+
+To enable a compute worker to work with the [MOS demo](https://github.com/Fuinn/mos-demo) on the same machine, specify the following values:
+
+* MOS_BACKEND_HOST=localhost
+* MOS_BACKEND_PORT=8000
+* MOS_ADMIN_USR=mos
+* MOS_ADMIN_PWD=demo
+* MOS_RABBIT_PORT=5672  
+* MOS_RABBIT_USR=guest
+* MOS_RABBIT_PWD=guest
+* MOS_RABBIT_HOST=localhost
+
 ## Local Deployment
 
 Launch a Julia worker by executing ``./workers/worker.jl``.


### PR DESCRIPTION
To run demo without workers, and provide workers from your own environment.